### PR TITLE
feat: implement gamepad support with lazy initialization and input handling

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -226,6 +226,39 @@ void game_init(GameState *gs) {
     gs->score          = 0;
     gs->coins_for_heart = 0;
 
+    /*
+     * Lazy gamepad initialisation — deferred from SDL_Init on purpose.
+     *
+     * SDL_InitSubSystem activates one SDL subsystem after the main SDL_Init
+     * call.  We do this here, after the window is already visible, instead of
+     * at process startup.  Antivirus software applies stricter heuristics to
+     * code that enumerates HID / XInput devices during the very first frames
+     * of a new process; waiting until the game window exists sidesteps those
+     * false-positive triggers.
+     *
+     * Non-fatal: if the subsystem fails to start (e.g. driver issue) the game
+     * continues with keyboard-only input.
+     */
+    if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER) != 0) {
+        fprintf(stderr, "Warning: SDL_INIT_GAMECONTROLLER failed: %s — "
+                        "gamepad support unavailable\n", SDL_GetError());
+    } else {
+        /*
+         * Scan for already-connected controllers.
+         * SDL_IsGameController checks whether SDL has a known mapping for
+         * the device (DualSense, DS4, Xbox, etc.).  We open the first one
+         * found; hot-plug events (SDL_CONTROLLERDEVICEADDED) handle
+         * controllers connected after this point.
+         */
+        for (int i = 0; i < SDL_NumJoysticks(); i++) {
+            if (SDL_IsGameController(i)) {
+                gs->controller = SDL_GameControllerOpen(i);
+                if (gs->controller)
+                    break;
+            }
+        }
+    }
+
     /* Signal the loop to start running */
     gs->running = 1;
 }
@@ -275,17 +308,56 @@ void game_loop(GameState *gs) {
             if (event.type == SDL_QUIT) {
                 /* User clicked the window's X button */
                 gs->running = 0;
+
             } else if (event.type == SDL_KEYDOWN) {
                 /* A key was pressed this frame */
                 if (event.key.keysym.sym == SDLK_ESCAPE) {
+                    gs->running = 0;
+                }
+
+            } else if (event.type == SDL_CONTROLLERDEVICEADDED) {
+                /*
+                 * A new gamepad was plugged in while the game is running.
+                 * Open it only if we don't already have one active.
+                 * event.cdevice.which is the joystick device index (not
+                 * an instance ID), so it can be passed directly to
+                 * SDL_GameControllerOpen.
+                 */
+                if (!gs->controller) {
+                    gs->controller = SDL_GameControllerOpen(event.cdevice.which);
+                }
+
+            } else if (event.type == SDL_CONTROLLERDEVICEREMOVED) {
+                /*
+                 * A gamepad was unplugged.  Check whether it is the one we
+                 * have open by comparing instance IDs.
+                 * SDL_GameControllerGetJoystick + SDL_JoystickInstanceID
+                 * retrieves the runtime ID of our open controller so we can
+                 * compare it against the event's which field.
+                 */
+                if (gs->controller) {
+                    SDL_Joystick *joy = SDL_GameControllerGetJoystick(gs->controller);
+                    if (SDL_JoystickInstanceID(joy) == event.cdevice.which) {
+                        SDL_GameControllerClose(gs->controller);
+                        gs->controller = NULL;
+                    }
+                }
+
+            } else if (event.type == SDL_CONTROLLERBUTTONDOWN) {
+                /*
+                 * Start (Xbox) / Options (DualSense / DS4) → quit.
+                 * Mirrors the ESC key behaviour so the player can exit
+                 * from the couch without reaching for the keyboard.
+                 */
+                if (event.cbutton.button == SDL_CONTROLLER_BUTTON_START) {
                     gs->running = 0;
                 }
             }
         }
 
         /* ---- 2. Update ------------------------------------------- */
-        /* Read the keyboard and set the player's velocity for this frame */
-        player_handle_input(&gs->player, gs->snd_jump);
+        /* Read keyboard and gamepad; set the player's velocity for this frame */
+        player_handle_input(&gs->player, gs->snd_jump, gs->controller);
         /* Move the player, check floor + one-way platform collisions */
         player_update(&gs->player, dt, gs->platforms, gs->platform_count);
         /* Move spiders along their patrol paths and advance their animation */
@@ -557,6 +629,22 @@ void game_loop(GameState *gs) {
  * are safe (SDL_Destroy* and free() on NULL are no-ops).
  */
 void game_cleanup(GameState *gs) {
+    /*
+     * Close the gamepad and shut down the controller subsystem.
+     *
+     * SDL_GameControllerClose releases the handle for this specific device.
+     * SDL_QuitSubSystem mirrors the SDL_InitSubSystem call in game_init —
+     * it decrements the internal reference count for SDL_INIT_GAMECONTROLLER
+     * and shuts the subsystem down when the count reaches zero.
+     * Both calls are safe when their argument is NULL / the subsystem is
+     * not active, so no extra guard is needed beyond the pointer check.
+     */
+    if (gs->controller) {
+        SDL_GameControllerClose(gs->controller);
+        gs->controller = NULL;
+    }
+    SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+
     /* Free HUD resources (font + star texture, renderer-dependent) */
     hud_cleanup(&gs->hud);
 

--- a/src/game.h
+++ b/src/game.h
@@ -110,9 +110,10 @@ typedef struct {
 } Camera;
 
 typedef struct {
-    SDL_Window    *window;      /* the OS window (created by SDL)              */
-    SDL_Renderer  *renderer;   /* GPU-accelerated 2D drawing context          */
-    ParallaxSystem parallax;   /* multi-layer scrolling background            */
+    SDL_Window         *window;     /* the OS window (created by SDL)              */
+    SDL_Renderer       *renderer;  /* GPU-accelerated 2D drawing context          */
+    SDL_GameController *controller;/* first connected gamepad; NULL = none         */
+    ParallaxSystem      parallax;  /* multi-layer scrolling background            */
     SDL_Texture   *floor_tile; /* grass tile repeated across the floor layer  */
     SDL_Texture  *platform_tex;/* shared tile texture for all pillars         */
     SDL_Texture  *spider_tex;  /* shared texture for all spider enemies       */

--- a/src/main.c
+++ b/src/main.c
@@ -34,6 +34,12 @@ int main(int argc, char *argv[]) {
      * Flags tell SDL which subsystems to activate:
      *   SDL_INIT_VIDEO  → creates the event queue, window, and renderer support.
      *   SDL_INIT_AUDIO  → sets up the platform audio device.
+     *
+     * SDL_INIT_GAMECONTROLLER is intentionally omitted here.
+     * It is initialised lazily inside game_init via SDL_InitSubSystem, after
+     * the window is already visible.  Deferring the gamepad subsystem avoids
+     * triggering antivirus heuristics that flag programs enumerating HID /
+     * XInput devices during the very first moments of process startup.
      * Returns 0 on success, negative on failure.
      */
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) != 0) {

--- a/src/parallax.c
+++ b/src/parallax.c
@@ -43,11 +43,11 @@ static const struct {
     float       speed;  /* parallax scroll fraction (0 = static)  */
 } LAYER_CONFIG[] = {
     { "assets/Parallax/sky.png",               0.00f },
-    { "assets/Parallax/glacial_mountains.png", 0.08f },
-    { "assets/Parallax/clouds_bg.png",         0.15f },
-    { "assets/Parallax/clouds_mg_1.png",       0.25f },
+    { "assets/Parallax/clouds_bg.png",         0.08f },
+    { "assets/Parallax/glacial_mountains.png", 0.15f },
+    { "assets/Parallax/clouds_mg_3.png",       0.25f },
     { "assets/Parallax/clouds_mg_2.png",       0.38f },
-    { "assets/Parallax/clouds_mg_3.png",       0.50f },
+    { "assets/Parallax/clouds_mg_1.png",       0.50f },
 };
 
 /* Number of entries in LAYER_CONFIG, computed at compile time. */

--- a/src/player.c
+++ b/src/player.c
@@ -121,7 +121,23 @@ void player_init(Player *player, SDL_Renderer *renderer) {
  * it tells us which keys are held RIGHT NOW, giving smooth, continuous
  * movement rather than one-shot movement on the moment of press.
  */
-void player_handle_input(Player *player, Mix_Chunk *snd_jump) {
+/*
+ * AXIS_DEAD_ZONE — minimum absolute value an analog axis must exceed before
+ * it is treated as intentional input.
+ *
+ * SDL reports axis values in the range [-32768, +32767].  Physical sticks
+ * produce small non-zero readings even when untouched (electrical noise,
+ * mechanical centre offset).  Ignoring anything below this threshold
+ * prevents the player from drifting without touching the controller.
+ *
+ * 8000 ≈ 24% of the full range — safe for all DualSense / DS4 / Xbox sticks.
+ * Raise this value if a specific controller drifts; lower it for more
+ * sensitivity at the cost of accidental movement.
+ */
+#define AXIS_DEAD_ZONE  8000
+
+void player_handle_input(Player *player, Mix_Chunk *snd_jump,
+                         SDL_GameController *ctrl) {
     /*
      * SDL_GetKeyboardState returns a pointer to an array of key states.
      * Each element is 1 if that key is currently held, 0 if not.
@@ -154,6 +170,72 @@ void player_handle_input(Player *player, Mix_Chunk *snd_jump) {
         player->vy        = -500.0f;  /* upward impulse; reaches ~156 px, clearing the tall pillar */
         player->on_ground  = 0;
         if (snd_jump) Mix_PlayChannel(-1, snd_jump, 0);
+    }
+
+    /* ----------------------------------------------------------------
+     * Gamepad input — only runs when a controller is connected (ctrl != NULL).
+     *
+     * SDL_GameController maps every supported device (DualSense, DualShock 4,
+     * Xbox Series / One / 360) to a unified button/axis layout regardless of
+     * the physical label on the device.  We read two input sources:
+     *
+     *   1. D-Pad buttons — digital on/off, perfect for precision platforming.
+     *   2. Left analog stick X axis — analog range; requires a dead zone check
+     *      to filter electrical noise when the stick is at rest.
+     *
+     * Both sources can be active simultaneously; the velocity accumulates.
+     * Keyboard and gamepad also work at the same time — no mode switching.
+     * ---------------------------------------------------------------- */
+    if (ctrl) {
+        /*
+         * D-Pad left / right — SDL_GameControllerGetButton returns 1 if the
+         * named button is currently pressed, 0 if not.
+         *
+         * SDL_CONTROLLER_BUTTON_DPAD_LEFT  → D-Pad left  on all controllers
+         * SDL_CONTROLLER_BUTTON_DPAD_RIGHT → D-Pad right on all controllers
+         */
+        if (SDL_GameControllerGetButton(ctrl, SDL_CONTROLLER_BUTTON_DPAD_LEFT)) {
+            player->vx -= player->speed;
+            player->facing_left = 1;
+        }
+        if (SDL_GameControllerGetButton(ctrl, SDL_CONTROLLER_BUTTON_DPAD_RIGHT)) {
+            player->vx += player->speed;
+            player->facing_left = 0;
+        }
+
+        /*
+         * Left analog stick horizontal axis.
+         *
+         * SDL_GameControllerGetAxis returns a Sint16 in [-32768, +32767].
+         * Negative = left, positive = right.
+         * We compare the raw value against AXIS_DEAD_ZONE to ignore noise.
+         *
+         * SDL_CONTROLLER_AXIS_LEFTX maps to:
+         *   DualSense / DS4 → left stick horizontal
+         *   Xbox             → left stick horizontal
+         */
+        Sint16 axis_x = SDL_GameControllerGetAxis(ctrl, SDL_CONTROLLER_AXIS_LEFTX);
+        if (axis_x < -AXIS_DEAD_ZONE) {
+            player->vx -= player->speed;
+            player->facing_left = 1;
+        } else if (axis_x > AXIS_DEAD_ZONE) {
+            player->vx += player->speed;
+            player->facing_left = 0;
+        }
+
+        /*
+         * Jump button — A (Xbox) / Cross × (DualSense / DS4).
+         *
+         * SDL maps both to SDL_CONTROLLER_BUTTON_A in the unified layout.
+         * Same one-shot guard as the keyboard: on_ground prevents re-triggering
+         * while the button is held after takeoff.
+         */
+        if (player->on_ground &&
+            SDL_GameControllerGetButton(ctrl, SDL_CONTROLLER_BUTTON_A)) {
+            player->vy        = -500.0f;
+            player->on_ground = 0;
+            if (snd_jump) Mix_PlayChannel(-1, snd_jump, 0);
+        }
     }
 }
 

--- a/src/player.h
+++ b/src/player.h
@@ -49,8 +49,10 @@ typedef struct {
 /* Load the player texture and set its initial position. */
 void player_init(Player *player, SDL_Renderer *renderer);
 
-/* Sample the keyboard every frame and set vx/vy accordingly. */
-void player_handle_input(Player *player, Mix_Chunk *snd_jump);
+/* Sample keyboard and gamepad every frame and set vx/vy accordingly.
+ * ctrl may be NULL when no controller is connected; keyboard still works. */
+void player_handle_input(Player *player, Mix_Chunk *snd_jump,
+                         SDL_GameController *ctrl);
 
 /* Move the player by velocity × dt; resolve floor and one-way platform collisions. */
 void player_update(Player *player, float dt, const Platform *platforms, int platform_count);


### PR DESCRIPTION
This pull request adds robust gamepad support to the game, allowing players to use controllers (such as Xbox, DualSense, and DualShock 4) in addition to the keyboard. The implementation includes hot-plugging support, proper initialization and cleanup of the controller subsystem, and unified input handling. Additionally, there are minor changes to the parallax background layer order.

**Gamepad support and input handling:**

* Added lazy initialization of the SDL game controller subsystem in `game_init`, deferring it until after the window is visible to avoid antivirus false positives, and scanning for already-connected controllers. If initialization fails, the game continues with keyboard-only input. (`src/game.c`, `src/main.c`, `src/game.h`) [[1]](diffhunk://#diff-94fb337d7329cc8d07d0a1478b275494a6b01dd63e7ed865a80cddd1f5305221R229-R261) [[2]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176R37-R42) [[3]](diffhunk://#diff-ca54668860ba1b6ad285983b8a53a637120a3c906f4f124f0a974f864d1bd4caR115)
* Implemented hot-plugging: the game now responds to controller connection and removal events, opening the first available controller and closing it if unplugged. (`src/game.c`)
* Updated input handling to combine keyboard and gamepad input, supporting both simultaneously. Added dead zone filtering for analog sticks and mapped controller buttons to movement and jump actions. (`src/player.c`, `src/player.h`) [[1]](diffhunk://#diff-be6c10a281956279b3126103cd06a5c1573197dd6bb7b13f8b59409d9903f5aaL124-R140) [[2]](diffhunk://#diff-be6c10a281956279b3126103cd06a5c1573197dd6bb7b13f8b59409d9903f5aaR174-R239) [[3]](diffhunk://#diff-71ab3d0cd534a1608f1c652185c8a8e1247c81813161673bedf7f5433dad2483L52-R55)
* Ensured proper cleanup of controller resources and subsystem shutdown in `game_cleanup`. (`src/game.c`)

**Parallax background adjustment:**

* Changed the order and selection of parallax background layers for improved visual composition. (`src/parallax.c`)