### PR TITLE
fix: disable gamepad input on WebAssembly to prevent ghost controller

### DIFF
--- a/src/player/player.c
+++ b/src/player/player.c
@@ -453,7 +453,13 @@ void player_handle_input(Player *player, Mix_Chunk *snd_jump,
      *
      * Both sources can be active simultaneously; the velocity accumulates.
      * Keyboard and gamepad also work at the same time — no mode switching.
+     *
+     * DISABLED ON WEBASSEMBLY: Emscripten's SDL gamepad implementation may
+     * report a "virtual" controller with non-zero axis values, causing the
+     * player to auto-move or override keyboard input. Skip gamepad entirely
+     * on __EMSCRIPTEN__ to ensure keyboard controls work correctly.
      * ---------------------------------------------------------------- */
+#ifndef __EMSCRIPTEN__
     if (ctrl) {
         /*
          * Vine grab via D-Pad UP — same logic as keyboard UP above.
@@ -581,6 +587,7 @@ void player_handle_input(Player *player, Mix_Chunk *snd_jump,
             }
         }
     }
+#endif /* __EMSCRIPTEN__ */
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- Wrapped gamepad input code in `#ifndef __EMSCRIPTEN__` to disable it entirely on WebAssembly builds
- Prevents Emscripten's SDL gamepad implementation from detecting a "virtual" controller with stuck axis values

## Problem
On WebAssembly, Emscripten may report a ghost gamepad even when none is connected. The axis values can be non-zero, causing:
- Player auto-moves right (axis reading above dead zone)
- Keyboard input gets overridden by ghost stick values
- Jump and climb controls fail to register (jump_held state corrupted)

## Solution
Disable gamepad input entirely on `__EMSCRIPTEN__` builds. Native builds continue to support gamepads normally.

## Testing
- Native builds: gamepad support unchanged
- WebAssembly: keyboard-only input, no ghost controller interference