### PR TITLE
fix: added fix to key press event to avoid false key down register wi…

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -50,6 +50,22 @@ int main(int argc, char *argv[]) {
             level_path = argv[i + 1];   /* next arg is consumed by the flag */
     }
     /*
+     * WebAssembly: attach SDL2's keyboard listeners to the canvas element
+     * instead of the document.  Without this hint, SDL2 registers keydown/keyup
+     * on the document and can miss the matching keyup when the canvas loses
+     * focus (e.g. user opens DevTools).  The missing keyup leaves the key
+     * "stuck" as pressed in SDL's state table, causing the player to walk or
+     * jump without input.  By binding to "#canvas", events only arrive while
+     * the canvas has focus and SDL naturally clears keys on blur.
+     *
+     * Must be called before SDL_Init so the hint is in place when SDL2
+     * registers its JavaScript event listeners during video initialisation.
+     */
+#ifdef __EMSCRIPTEN__
+    SDL_SetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT, "#canvas");
+#endif
+
+    /*
      * SDL_Init — start the SDL core.
      * Flags tell SDL which subsystems to activate:
      *   SDL_INIT_VIDEO  → creates the event queue, window, and renderer support.

--- a/web/shell.html
+++ b/web/shell.html
@@ -99,6 +99,52 @@
         e.preventDefault();
       }
     }, false);
+
+    /*
+     * Stuck-key fix: fire synthetic keyup events for every game input key
+     * whenever the canvas (or the whole window) loses focus.
+     *
+     * SDL2 registers keydown/keyup listeners and maintains an internal key-
+     * state table.  When focus moves away (DevTools, address bar, alt-tab)
+     * the browser may deliver a keydown without the matching keyup, leaving
+     * the key permanently "pressed" in SDL's table.  The player then walks
+     * or jumps without any physical input.
+     *
+     * Dispatching synthetic keyup events on the canvas flushes SDL's state
+     * for all relevant keys.  bubbles:true lets the events reach SDL whether
+     * it is listening on the canvas element (SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT)
+     * or higher up the DOM (document/window default).
+     */
+    (function() {
+      var GAME_KEYS = [
+        'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',
+        'Space', 'KeyA', 'KeyD', 'KeyW', 'KeyS',
+        'ShiftLeft', 'ShiftRight'
+      ];
+
+      function releaseGameKeys() {
+        var c = document.getElementById('canvas');
+        if (!c) return;
+        GAME_KEYS.forEach(function(code) {
+          c.dispatchEvent(new KeyboardEvent('keyup', {
+            code: code,
+            bubbles: true,
+            cancelable: true
+          }));
+        });
+      }
+
+      /* Canvas blur: covers DevTools, address bar, any in-page focus shift. */
+      document.getElementById('canvas').addEventListener('blur', releaseGameKeys);
+
+      /* Window blur: covers alt-tab, clicking another application. */
+      window.addEventListener('blur', releaseGameKeys);
+
+      /* Tab hidden: covers switching browser tabs. */
+      document.addEventListener('visibilitychange', function() {
+        if (document.hidden) releaseGameKeys();
+      });
+    }());
   </script>
   {{{ SCRIPT }}}
 </body>


### PR DESCRIPTION
This pull request addresses a longstanding issue where keyboard input could get "stuck" when the game canvas loses focus, causing unintended continuous movement or actions in the game. The changes ensure that SDL2's keyboard event handling is more robust, especially in WebAssembly builds, and introduce a JavaScript workaround to flush stuck keys when focus is lost.

**WebAssembly/SDL2 keyboard event handling:**

* In `src/main.c`, added a call to `SDL_SetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT, "#canvas")` before `SDL_Init` in WebAssembly builds, so SDL2 attaches its keyboard listeners to the canvas element instead of the document. This prevents keys from getting stuck when the canvas loses focus.

**Frontend stuck-key workaround:**

* In `web/shell.html`, added a JavaScript function that dispatches synthetic `keyup` events for all game input keys whenever the canvas or window loses focus, or when the browser tab is hidden. This ensures SDL2's internal key state is correctly reset in all focus loss scenarios, preventing stuck input.…thout proper follow up with key up locking the player on permanent input

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

## Test Plan

<!-- How were these changes tested? -->
