### PR TITLE
refactor: standardize Google Analytics component

### DIFF
--- a/docs/src/components/Analytics.astro
+++ b/docs/src/components/Analytics.astro
@@ -1,0 +1,18 @@
+---
+const GA_ID = import.meta.env.PUBLIC_GA_ID;
+---
+
+{GA_ID && (
+  <>
+    <script
+      async
+      src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+    ></script>
+    <script define:vars={{ GA_ID }}>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() { dataLayer.push(arguments); }
+      gtag('js', new Date());
+      gtag('config', GA_ID);
+    </script>
+  </>
+)}

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/globals.css";
+import Analytics from '../components/Analytics.astro';
 
 interface Props {
     title?: string;
@@ -10,8 +11,6 @@ const {
     title = "Super Mango - 2D Pixel Art Platformer",
     description = "A 2D pixel art platformer written in C11 + SDL2. Play in your browser via WebAssembly or download for macOS, Linux, and Windows.",
 } = Astro.props;
-
-const GA_ID = import.meta.env.PUBLIC_GA_ID;
 
 const jsonLd = {
     "@context": "https://schema.org",
@@ -67,23 +66,11 @@ const jsonLd = {
         />
 
         <title>{title}</title>
+        <Analytics />
 
         <script type="application/ld+json" set:html={JSON.stringify(jsonLd)} />
     </head>
     <body>
-        {GA_ID && (
-            <script
-                async
-                src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
-                is:inline
-            />
-            <script define:vars={{ GA_ID }} is:inline>
-                window.dataLayer = window.dataLayer || [];
-                function gtag() { dataLayer.push(arguments); }
-                gtag('js', new Date());
-                gtag('config', GA_ID);
-            </script>
-        )}
         <slot />
     </body>
 </html>


### PR DESCRIPTION
## Summary

This PR standardizes the Google Analytics implementation to match the pattern used in `jonathanperis.github.io` and `grande-livro-maconaria`.

### Changes
- Create `docs/src/components/Analytics.astro` with GA_ID environment variable
- Remove inline GA code from `BaseLayout.astro`
- Add conditional rendering `{GA_ID && (...)}` pattern
- Import Analytics component in BaseLayout

### Benefits
- Clean separation of concerns
- Conditional rendering prevents errors when GA_ID is missing
- Easier to maintain and consistent across all GH Pages repos
- Reusable component pattern