### PR TITLE
Fix startup segfault in level path resolution

### DIFF
--- a/levels/untitled.toml
+++ b/levels/untitled.toml
@@ -1,0 +1,30 @@
+name = "Untitled"
+screen_count = 4
+player_start_x = 48.0
+player_start_y = 205.0
+music_path = ""
+music_volume = 0
+floor_tile_path = "assets/sprites/levels/grass_tileset.png"
+initial_hearts = 0
+initial_lives = 0
+score_per_life = 0
+coin_score = 0
+
+[physics]
+walk_max_speed       = 0.0
+run_max_speed        = 0.0
+walk_ground_accel    = 0.0
+run_ground_accel     = 0.0
+ground_friction      = 0.0
+ground_counter_accel = 0.0
+air_accel_walk       = 0.0
+air_accel_run        = 0.0
+air_friction         = 0.0
+cam_lookahead_vx_factor = 0.0
+cam_lookahead_max    = 0.0
+
+
+[last_star]
+x = 145.0
+y = 167.0
+

--- a/src/game.c
+++ b/src/game.c
@@ -2,6 +2,12 @@
  * game.c — Window, renderer, background, and main game loop.
  */
 
+#if !defined(_WIN32) && !defined(__EMSCRIPTEN__)
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE 700
+#endif
+#endif
+
 #include <SDL.h>
 #include <SDL_image.h>
 #include <SDL_mixer.h>
@@ -15,6 +21,9 @@
 #include <windows.h> /* GetFullPathNameA */
 #elif !defined(__EMSCRIPTEN__)
 #include <limits.h>  /* PATH_MAX */
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
 #endif
 
 #include "game.h"
@@ -369,10 +378,9 @@ void game_init(GameState *gs) {
             path_valid = 1;
         }
 #else
-        char *resolved = realpath(gs->level_path, NULL);
-        if (resolved) {
+    char resolved[PATH_MAX];
+    if (realpath(gs->level_path, resolved) != NULL) {
             strncpy(safe_path, resolved, sizeof(safe_path) - 1);
-            free(resolved);
             path_valid = 1;
         }
 #endif


### PR DESCRIPTION
## Summary\n- fix startup crash entering gameplay caused by unsafe level-path canonicalization under strict C11\n- ensure POSIX path resolution uses a properly declared and safe realpath flow\n- keep behavior unchanged for Windows and Emscripten paths\n\n## Validation\n- make -j4\n- ./out/super-mango --sandbox (startup no longer segfaults)