### PR TITLE
fix: add scrollbar for overflow in properties menu

### DIFF
--- a/src/editor/palette.c
+++ b/src/editor/palette.c
@@ -169,6 +169,18 @@ static const PaletteEntry entries[] = {
  */
 #define PAD_X           12
 
+/*
+ * SCROLLBAR_W — width in pixels of the vertical scrollbar on the right
+ * edge of the palette panel.
+ */
+#define SCROLLBAR_W     8
+
+/*
+ * SCROLLBAR_MIN_THUMB_H — minimum thumb height in pixels.
+ * Prevents the thumb from becoming too small to click when content is vast.
+ */
+#define SCROLLBAR_MIN_THUMB_H 20
+
 /* ------------------------------------------------------------------ */
 /* Scroll state — retained across frames                               */
 /* ------------------------------------------------------------------ */
@@ -190,6 +202,18 @@ static int scroll_y = 0;
  * All start expanded.  Clicking a category header toggles it.
  */
 static int category_open[6] = { 0, 0, 0, 0, 0, 0 };
+
+/*
+ * Scrollbar drag state — retained across frames so a drag that started on
+ * the thumb continues even if the cursor leaves the thumb area.
+ *
+ * sb_dragging           : 1 while the user holds the mouse on the thumb.
+ * sb_drag_anchor_y      : mouse_y at the moment the drag began.
+ * sb_drag_anchor_scroll : scroll_y at the moment the drag began.
+ */
+static int sb_dragging           = 0;
+static int sb_drag_anchor_y      = 0;
+static int sb_drag_anchor_scroll = 0;
 
 /*
  * palette_scroll — Adjust the palette scroll offset by a pixel delta.
@@ -529,6 +553,102 @@ void palette_render(EditorState *es, int start_y, int available_h)
             /* Advance cursor past this entity row. */
             cursor_y += ROW_H;
         }
+    }
+
+    /* ---- Scrollbar ---- */
+
+    /*
+     * Only draw the scrollbar when there is content that overflows the
+     * visible area.  When everything fits, the scrollbar would be invisible
+     * (thumb == track height) so we skip it entirely.
+     */
+    if (scrollable_h > 0) {
+        int track_x = panel_x + PANEL_W - SCROLLBAR_W;
+        int track_y = content_top;
+        int track_h = panel_h - TITLE_H;
+
+        /*
+         * Thumb height — proportional to the ratio of visible area to total
+         * scrollable content.  Clamped to a minimum so it stays clickable.
+         *
+         * total_scroll_content is total_content_h minus the fixed title bar,
+         * i.e. the full height of the scrolling content region.
+         */
+        int total_scroll_content = total_content_h - TITLE_H;
+        int thumb_h = (int)((float)track_h * (float)track_h / (float)total_scroll_content);
+        if (thumb_h < SCROLLBAR_MIN_THUMB_H) thumb_h = SCROLLBAR_MIN_THUMB_H;
+        if (thumb_h > track_h)              thumb_h = track_h;
+
+        int travel = track_h - thumb_h; /* pixels the thumb can move */
+
+        /* Compute thumb top edge from current scroll position. */
+        int thumb_y = track_y + (travel > 0 ? (int)((float)scroll_y / scrollable_h * travel) : 0);
+
+        /* ---- Handle drag input ---- */
+
+        int in_thumb = point_in_rect(ui->mouse_x, ui->mouse_y,
+                                     track_x, thumb_y, SCROLLBAR_W, thumb_h);
+        int in_track = point_in_rect(ui->mouse_x, ui->mouse_y,
+                                     track_x, track_y, SCROLLBAR_W, track_h);
+
+        if (sb_dragging) {
+            if (ui->mouse_down) {
+                /*
+                 * Continue drag — translate mouse movement into scroll offset.
+                 * dy pixels of mouse movement → (dy / travel) * scrollable_h
+                 * pixels of content scroll.
+                 */
+                if (travel > 0) {
+                    int dy = ui->mouse_y - sb_drag_anchor_y;
+                    scroll_y = sb_drag_anchor_scroll + (int)((float)dy * scrollable_h / travel);
+                    if (scroll_y < 0)           scroll_y = 0;
+                    if (scroll_y > scrollable_h) scroll_y = scrollable_h;
+                }
+            } else {
+                sb_dragging = 0; /* mouse released — end drag */
+            }
+        } else if (in_thumb && ui->mouse_clicked) {
+            /* Start drag from the thumb. */
+            sb_dragging           = 1;
+            sb_drag_anchor_y      = ui->mouse_y;
+            sb_drag_anchor_scroll = scroll_y;
+        } else if (in_track && !in_thumb && ui->mouse_clicked) {
+            /*
+             * Click on the track outside the thumb — jump so the thumb
+             * centre aligns with the click position.
+             */
+            if (travel > 0) {
+                float ratio = (float)(ui->mouse_y - track_y - thumb_h / 2) / (float)travel;
+                if (ratio < 0.0f) ratio = 0.0f;
+                if (ratio > 1.0f) ratio = 1.0f;
+                scroll_y = (int)(ratio * scrollable_h);
+            }
+        }
+
+        /* Recompute thumb_y after any scroll_y update this frame. */
+        thumb_y = track_y + (travel > 0 ? (int)((float)scroll_y / scrollable_h * travel) : 0);
+
+        /* ---- Draw track ---- */
+
+        SDL_Color track_col = UI_INPUT_BG;
+        SDL_SetRenderDrawColor(ui->renderer,
+                               track_col.r, track_col.g, track_col.b, track_col.a);
+        SDL_Rect track_rect = { track_x, track_y, SCROLLBAR_W, track_h };
+        SDL_RenderFillRect(ui->renderer, &track_rect);
+
+        /* ---- Draw thumb ---- */
+
+        /*
+         * Thumb colour: bright when dragging or hovering, dim when idle.
+         * This gives the user immediate visual feedback that the scrollbar
+         * is interactive.
+         */
+        SDL_Color thumb_col = (sb_dragging || in_thumb) ? UI_BTN_HOT : UI_BTN;
+        SDL_SetRenderDrawColor(ui->renderer,
+                               thumb_col.r, thumb_col.g, thumb_col.b, thumb_col.a);
+        /* 1px inset on each side so the thumb has a small visual gap from track edges. */
+        SDL_Rect thumb_rect = { track_x + 1, thumb_y + 1, SCROLLBAR_W - 2, thumb_h - 2 };
+        SDL_RenderFillRect(ui->renderer, &thumb_rect);
     }
 
     /* Remove clip rect so other panels are not affected */

--- a/src/editor/properties.c
+++ b/src/editor/properties.c
@@ -53,6 +53,11 @@
 #define CONTENT_X  (PROP_X + 8)
 #define FIELD_X    (CONTENT_X + LABEL_W)
 
+/* SCROLLBAR_W — width of the vertical scrollbar on the panel's right edge. */
+#define SCROLLBAR_W            8
+/* SCROLLBAR_MIN_THUMB_H — minimum thumb height to stay clickable. */
+#define SCROLLBAR_MIN_THUMB_H  20
+
 /* Collapsible subsection open states — accessed by editor.c for config_h computation */
 int g_plx_open  = 0;
 int g_fg_open   = 0;
@@ -75,6 +80,19 @@ static int cfg_scroll_y = 0;
 void cfg_scroll(int delta) {
     cfg_scroll_y += delta;
     if (cfg_scroll_y < 0) cfg_scroll_y = 0;
+}
+
+/*
+ * cfg_sb_* — scrollbar drag state for the Level Config panel.
+ * Mirrors the palette's sb_* variables; kept separate to avoid coupling.
+ */
+static int cfg_sb_dragging           = 0;
+static int cfg_sb_drag_anchor_y      = 0;
+static int cfg_sb_drag_anchor_scroll = 0;
+
+/* point_in_rect — axis-aligned hit test (duplicated from palette.c; static = private). */
+static int point_in_rect(int px, int py, int rx, int ry, int rw, int rh) {
+    return px >= rx && px < rx + rw && py >= ry && py < ry + rh;
 }
 
 /* ------------------------------------------------------------------ */
@@ -1665,5 +1683,72 @@ fg_done:
     }
 
 fog_done:
+
+    /* ---- Scrollbar ---- */
+
+    if (max_scroll > 0) {
+        int track_x = x + PROP_W - SCROLLBAR_W;
+        int track_y = content_top;
+        int track_h = content_visible_h;
+
+        /*
+         * Thumb height — proportional to visible/total content ratio.
+         * Since track_h == content_visible_h, the formula simplifies to
+         * track_h * track_h / content_total_h.
+         */
+        int thumb_h = (int)((float)track_h * (float)track_h / (float)content_total_h);
+        if (thumb_h < SCROLLBAR_MIN_THUMB_H) thumb_h = SCROLLBAR_MIN_THUMB_H;
+        if (thumb_h > track_h)              thumb_h = track_h;
+
+        int travel  = track_h - thumb_h;
+        int thumb_y = track_y + (travel > 0 ? (int)((float)cfg_scroll_y / max_scroll * travel) : 0);
+
+        int in_thumb = point_in_rect(es->ui.mouse_x, es->ui.mouse_y,
+                                     track_x, thumb_y, SCROLLBAR_W, thumb_h);
+        int in_track = point_in_rect(es->ui.mouse_x, es->ui.mouse_y,
+                                     track_x, track_y, SCROLLBAR_W, track_h);
+
+        if (cfg_sb_dragging) {
+            if (es->ui.mouse_down) {
+                if (travel > 0) {
+                    int dy = es->ui.mouse_y - cfg_sb_drag_anchor_y;
+                    cfg_scroll_y = cfg_sb_drag_anchor_scroll + (int)((float)dy * max_scroll / travel);
+                    if (cfg_scroll_y < 0)          cfg_scroll_y = 0;
+                    if (cfg_scroll_y > max_scroll) cfg_scroll_y = max_scroll;
+                }
+            } else {
+                cfg_sb_dragging = 0;
+            }
+        } else if (in_thumb && es->ui.mouse_clicked) {
+            cfg_sb_dragging           = 1;
+            cfg_sb_drag_anchor_y      = es->ui.mouse_y;
+            cfg_sb_drag_anchor_scroll = cfg_scroll_y;
+        } else if (in_track && !in_thumb && es->ui.mouse_clicked) {
+            if (travel > 0) {
+                float ratio = (float)(es->ui.mouse_y - track_y - thumb_h / 2) / (float)travel;
+                if (ratio < 0.0f) ratio = 0.0f;
+                if (ratio > 1.0f) ratio = 1.0f;
+                cfg_scroll_y = (int)(ratio * max_scroll);
+            }
+        }
+
+        /* Recompute after potential scroll_y update this frame. */
+        thumb_y = track_y + (travel > 0 ? (int)((float)cfg_scroll_y / max_scroll * travel) : 0);
+
+        /* Track */
+        SDL_Color track_col = UI_INPUT_BG;
+        SDL_SetRenderDrawColor(es->ui.renderer,
+                               track_col.r, track_col.g, track_col.b, track_col.a);
+        SDL_Rect track_rect = { track_x, track_y, SCROLLBAR_W, track_h };
+        SDL_RenderFillRect(es->ui.renderer, &track_rect);
+
+        /* Thumb */
+        SDL_Color thumb_col = (cfg_sb_dragging || in_thumb) ? UI_BTN_HOT : UI_BTN;
+        SDL_SetRenderDrawColor(es->ui.renderer,
+                               thumb_col.r, thumb_col.g, thumb_col.b, thumb_col.a);
+        SDL_Rect thumb_rect = { track_x + 1, thumb_y + 1, SCROLLBAR_W - 2, thumb_h - 2 };
+        SDL_RenderFillRect(es->ui.renderer, &thumb_rect);
+    }
+
     SDL_RenderSetClipRect(es->ui.renderer, NULL);
 }


### PR DESCRIPTION
Adds custom scrollbar rendering for overflow situations in the editor's properties menu and palette panels.